### PR TITLE
fix generic implementation type handling of Add*AssignableTo methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.6] - 2025-01-09
+
+### Fixed
+
+- Special case for generic types in the `Add*AssignableTo` extension methods.
+
+### Fixed
+
+- Readme header.
+
 ## [1.0.5] - 2025-01-09
 
 ### Added
@@ -16,10 +26,6 @@ and adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Changelog links.
-
-### Changed
-
-- Documentation of the `Add*AssignableTo` extension methods.
 
 ## [1.0.4] - 2025-01-09
 
@@ -50,6 +56,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Adding services assignable to a type to an `IServiceCollection`.
 - Converting hosted services to modular tenant events.
 
+[1.0.6]:
+  https://github.com/altibiz/extensions-dependency-injection/compare/1.0.5...1.0.6
 [1.0.5]:
   https://github.com/altibiz/extensions-dependency-injection/compare/1.0.4...1.0.5
 [1.0.4]:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Altibiz.DependencyInjection
+# Altibiz.DependencyInjection.Extensions
 
 Collection of extensions used by multiple Altibiz projects.
 

--- a/docs/wiki/adding-services.md
+++ b/docs/wiki/adding-services.md
@@ -18,8 +18,8 @@ Example of usage from tests:
 
 ```cs
 {{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:1:7 }}
-{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:8:133 }}
-{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:207: }}
+{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:8:137 }}
+{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:216: }}
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/docs/wiki/converting-hosted-services-to-modular-tenant-events.md
+++ b/docs/wiki/converting-hosted-services-to-modular-tenant-events.md
@@ -19,8 +19,8 @@ Example of usage from tests:
 
 ```cs
 {{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:1:7 }}
-{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:135:207 }}
-{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:208: }}
+{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:139:215 }}
+{{ #include ../../test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs:216: }}
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/src/Altibiz.DependencyInjection.Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altibiz.DependencyInjection.Extensions/ServiceCollectionExtensions.cs
@@ -258,6 +258,11 @@ public static class ServiceCollectionExtensions
         conversionType,
         lifetime);
       services.Add(conversionTypeDescriptor);
+      if (conversionType.ContainsGenericParameters)
+      {
+        continue;
+      }
+
       foreach (var interfaceType in conversionType
         .GetAllInterfaces()
         .OrderBy(type => type.FullName))

--- a/test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs
+++ b/test/Altibiz.DependencyInjection.Extensions.Test/ServiceCollectionExtensionsTest.cs
@@ -70,6 +70,10 @@ public class ServiceCollectionExtensionsTest
         typeof(FirstImplementation),
         lifetime),
       new ServiceDescriptor(
+        typeof(GenericImplementation<>),
+        typeof(GenericImplementation<>),
+        lifetime),
+      new ServiceDescriptor(
         typeof(SecondImplementation),
         typeof(SecondImplementation),
         lifetime),
@@ -146,6 +150,7 @@ public class ServiceCollectionExtensionsTest
         service =>
           service.ImplementationType == typeof(FirstImplementation)
           || service.ImplementationType == typeof(SecondImplementation)
+          || service.ImplementationType == typeof(GenericImplementation<>)
           || (service.ImplementationType is { IsGenericType: true } &&
             service.ImplementationType?.GetGenericTypeDefinition()
             == typeof(HostedServiceModularTenantEvents<>)))
@@ -160,6 +165,10 @@ public class ServiceCollectionExtensionsTest
       new ServiceDescriptor(
         typeof(IInterface),
         typeof(FirstImplementation),
+        ServiceLifetime.Singleton),
+      new ServiceDescriptor(
+        typeof(GenericImplementation<>),
+        typeof(GenericImplementation<>),
         ServiceLifetime.Singleton),
       new ServiceDescriptor(
         typeof(SecondImplementation),
@@ -224,6 +233,21 @@ internal class FirstImplementation : IInterface, IHostedService
 }
 
 internal class SecondImplementation : IInterface, IHostedService
+{
+  public Task StartAsync(CancellationToken cancellationToken)
+  {
+    throw new NotImplementedException();
+  }
+
+  public Task StopAsync(CancellationToken cancellationToken)
+  {
+    throw new NotImplementedException();
+  }
+}
+
+#pragma warning disable S2326 // Unused type parameters should be removed
+internal class GenericImplementation<T> : IInterface, IHostedService
+#pragma warning restore S2326 // Unused type parameters should be removed
 {
   public Task StartAsync(CancellationToken cancellationToken)
   {


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [x] I have added an entry to the [CHANGELOG.md](../CHANGELOG.md) document.

## Description

Ignored registering interfaces for generic implementation types in `Add*AssignableTo` methods.

## Testing

Adjusted tests of `Add*AssignableTo` to test for generic implementation types.

## Documentation

Adjusted documentation of `Add*AssignableTo`.
