### PR TITLE
fix stopping hosted service deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.9] - 2025-01-12
+
+### Fixed
+
+- Wrapped stopping `IHostedService` calls in `Task.Run` to avoid deadlocks.
+
 ## [1.0.8] - 2025-01-12
 
 ### Fixed
@@ -74,6 +80,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 - Adding services assignable to a type to an `IServiceCollection`.
 - Converting hosted services to modular tenant events.
 
+[1.0.9]:
+  https://github.com/altibiz/extensions-dependency-injection/compare/1.0.8...1.0.9
 [1.0.8]:
   https://github.com/altibiz/extensions-dependency-injection/compare/1.0.7...1.0.8
 [1.0.7]:

--- a/src/Altibiz.DependencyInjection.Extensions/HostedLifecycleServiceModularTenantEvents.cs
+++ b/src/Altibiz.DependencyInjection.Extensions/HostedLifecycleServiceModularTenantEvents.cs
@@ -92,12 +92,12 @@ internal sealed class HostedLifecycleServiceModularTenantEvents<THostedService>
 
   private void Stopping()
   {
-    StoppingAsync().GetAwaiter().GetResult();
+    Task.Run(StoppingAsync).GetAwaiter().GetResult();
   }
 
   private void Stopped()
   {
-    StoppedAsync().GetAwaiter().GetResult();
+    Task.Run(StoppedAsync).GetAwaiter().GetResult();
   }
 
   private async Task StartingAsync()

--- a/src/Altibiz.DependencyInjection.Extensions/HostedServiceModularTenantEvents.cs
+++ b/src/Altibiz.DependencyInjection.Extensions/HostedServiceModularTenantEvents.cs
@@ -78,7 +78,7 @@ internal sealed class HostedServiceModularTenantEvents<THostedService>
 
   private void Stop()
   {
-    StopAsync().GetAwaiter().GetResult();
+    Task.Run(StopAsync).GetAwaiter().GetResult();
   }
 
   private async Task StartAsync()


### PR DESCRIPTION
# Task

@HrvojeJuric

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [x] I have added an entry to the [CHANGELOG.md](../CHANGELOG.md) document.

## Description

Wrapped stopping `IHostedService` callbacks in `Task.Run` to prevent deadlocks.

## Testing

None.

## Documentation

None.
